### PR TITLE
Fixed repo links.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tokumori/naked-nudeles.git"
+    "url": "git+https://github.com/STUPIDSHITNOONEINHAWAIINEEDSHACKATHON/naked-nudeles.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/tokumori/naked-nudeles/issues"
+    "url": "https://github.com/STUPIDSHITNOONEINHAWAIINEEDSHACKATHON/naked-nudeles/issues"
   },
-  "homepage": "https://github.com/tokumori/naked-nudeles#readme"
+  "homepage": "https://github.com/STUPIDSHITNOONEINHAWAIINEEDSHACKATHON/naked-nudeles#readme"
 }


### PR DESCRIPTION
All links in `package.json` now link to the proper repo.